### PR TITLE
Fix replica build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ RN4UE4.VC.db
 RN4UE4.xcworkspace
 RN4UE4.VC.VC.opendb
 /enc_temp_folder
+/Plugins/Replicas/Source/Replicas/Source/
+/Plugins/Replicas/Binaries/Win64

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "PhysX-3.4"]
 	path = PhysX-3.4
-	url = https://github.com/Alexthegr92/PhysX-3.4
+	url = git@github.com:Alexthegr92/PhysX-3.4

--- a/Plugins/Replicas/Replicas.uplugin
+++ b/Plugins/Replicas/Replicas.uplugin
@@ -1,34 +1,34 @@
 {
-  "FileVersion": 3,
-  "Version": 1,
-  "VersionName": "1.0",
-  "FriendlyName": "Replicas",
-  "Description": "Replicas",
-  "Category": "Other",
-  "CreatedBy": "Alex",
-  "CreatedByURL": "",
-  "DocsURL": "",
-  "MarketplaceURL": "",
-  "SupportURL": "",
-  "CanContainContent": true,
-  "IsBetaVersion": false,
-  "Installed": false,
-  "Modules": [
-    {
-      "Name": "Replicas",
-      "Type": "RunTime",
-      "LoadingPhase": "Default"
-    }
-  ],
-  "Plugins": [
-    {
-      "Name": "RakNet",
-      "Enabled": true
-    }
-  ],
-  "PreBuildSteps": {
-    "Win64": [
-      "xcopy $(ProjectDir)\\PhysX-3.4\\PhysX_3.4\\Samples\\Replicas\\Source $(ProjectDir)\\Plugins\\Replicas\\Source\\Replicas\\Source /e /i /y"
-    ]
-  }
+	"FileVersion": 3,
+	"Version": 1,
+	"VersionName": "1.0",
+	"FriendlyName": "Replicas",
+	"Description": "Replicas",
+	"Category": "Other",
+	"CreatedBy": "Alex",
+	"CreatedByURL": "",
+	"DocsURL": "",
+	"MarketplaceURL": "",
+	"SupportURL": "",
+	"CanContainContent": true,
+	"IsBetaVersion": false,
+	"Installed": false,
+	"Modules": [
+		{
+			"Name": "Replicas",
+			"Type": "RunTime",
+			"LoadingPhase": "Default"
+		}
+	],
+	"Plugins": [
+		{
+			"Name": "RakNet",
+			"Enabled": true
+		}
+	],
+	"PreBuildSteps": {
+		"Win64": [
+			"xcopy $(ProjectDir)\\PhysX-3.4\\PhysX_3.4\\Samples\\Replicas\\Source $(ProjectDir)\\Plugins\\Replicas\\Source\\Replicas\\Source /e /i /y"
+		]
+	}
 }

--- a/Plugins/Replicas/Replicas.uplugin
+++ b/Plugins/Replicas/Replicas.uplugin
@@ -1,29 +1,34 @@
 {
-	"FileVersion": 3,
-	"Version": 1,
-	"VersionName": "1.0",
-	"FriendlyName": "Replicas",
-	"Description": "Replicas",
-	"Category": "Other",
-	"CreatedBy": "Alex",
-	"CreatedByURL": "",
-	"DocsURL": "",
-	"MarketplaceURL": "",
-	"SupportURL": "",
-	"CanContainContent": true,
-	"IsBetaVersion": false,
-	"Installed": false,
-	"Modules": [
-		{
-			"Name": "Replicas",
-			"Type": "RunTime",
-			"LoadingPhase": "Default"
-		}
-	],
+  "FileVersion": 3,
+  "Version": 1,
+  "VersionName": "1.0",
+  "FriendlyName": "Replicas",
+  "Description": "Replicas",
+  "Category": "Other",
+  "CreatedBy": "Alex",
+  "CreatedByURL": "",
+  "DocsURL": "",
+  "MarketplaceURL": "",
+  "SupportURL": "",
+  "CanContainContent": true,
+  "IsBetaVersion": false,
+  "Installed": false,
+  "Modules": [
+    {
+      "Name": "Replicas",
+      "Type": "RunTime",
+      "LoadingPhase": "Default"
+    }
+  ],
   "Plugins": [
     {
       "Name": "RakNet",
       "Enabled": true
     }
-  ]  
+  ],
+  "PreBuildSteps": {
+    "Win64": [
+      "xcopy $(ProjectDir)\\PhysX-3.4\\PhysX_3.4\\Samples\\Replicas\\Source $(ProjectDir)\\Plugins\\Replicas\\Source\\Replicas\\Source /e /i /y"
+    ]
+  }
 }

--- a/Plugins/Replicas/Source/Replicas/Include
+++ b/Plugins/Replicas/Source/Replicas/Include
@@ -1,1 +1,0 @@
-D:/Git/OrionVisualiser/PhysX-3.4/PhysX_3.4/Samples/Replicas/Include

--- a/Plugins/Replicas/Source/Replicas/Replicas.Build.cs
+++ b/Plugins/Replicas/Source/Replicas/Replicas.Build.cs
@@ -1,5 +1,6 @@
 // Copyright 1998-2018 Epic Games, Inc. All Rights Reserved.
 
+using System.IO;
 using UnrealBuildTool;
 
 public class Replicas : ModuleRules
@@ -9,5 +10,7 @@ public class Replicas : ModuleRules
         PCHUsage = ModuleRules.PCHUsageMode.UseExplicitOrSharedPCHs;
 
         PublicDependencyModuleNames.AddRange(new string[] { "Core", "RakNet" });
+
+        PublicIncludePaths.Add(Path.GetFullPath(Path.Combine(ModuleDirectory, "../../../../PhysX-3.4/PhysX_3.4/Samples/Replicas/Include")));
     }
 }

--- a/Plugins/Replicas/Source/Replicas/Replicas.Build.cs
+++ b/Plugins/Replicas/Source/Replicas/Replicas.Build.cs
@@ -1,48 +1,13 @@
 // Copyright 1998-2018 Epic Games, Inc. All Rights Reserved.
 
-using System.IO;
 using UnrealBuildTool;
 
 public class Replicas : ModuleRules
 {
-	public Replicas(ReadOnlyTargetRules Target) : base(Target)
-	{
-		PCHUsage = ModuleRules.PCHUsageMode.UseExplicitOrSharedPCHs;
-		
-		PublicIncludePaths.AddRange(
-			new string[] {
-				"Replicas/Public",
-                "Replicas/Include"
-				// ... add public include paths required here ...
-			}
-			);
+    public Replicas(ReadOnlyTargetRules Target) : base(Target)
+    {
+        PCHUsage = ModuleRules.PCHUsageMode.UseExplicitOrSharedPCHs;
 
-        PrivateIncludePaths.AddRange(
-			new string[] {
-                "Replicas/Private",
-				"Replicas/Source"
-				// ... add other private include paths required here ...
-			}
-			);
-
-
-        PublicDependencyModuleNames.AddRange(
-			new string[]
-			{
-				"Core",
-                "Projects",
-                "RakNet"
-				// ... add other public dependencies that you statically link with here ...
-			}
-			);
-			
-		
-		PrivateDependencyModuleNames.AddRange(
-			new string[]
-			{
-				"RakNet"
-				// ... add private dependencies that you statically link with here ...	
-			}
-			);
-	}
+        PublicDependencyModuleNames.AddRange(new string[] { "Core", "RakNet" });
+    }
 }

--- a/Plugins/Replicas/Source/Replicas/Replicas.Build.cs
+++ b/Plugins/Replicas/Source/Replicas/Replicas.Build.cs
@@ -5,12 +5,12 @@ using UnrealBuildTool;
 
 public class Replicas : ModuleRules
 {
-    public Replicas(ReadOnlyTargetRules Target) : base(Target)
-    {
-        PCHUsage = ModuleRules.PCHUsageMode.UseExplicitOrSharedPCHs;
+	public Replicas(ReadOnlyTargetRules Target) : base(Target)
+	{
+		PCHUsage = ModuleRules.PCHUsageMode.UseExplicitOrSharedPCHs;
 
-        PublicDependencyModuleNames.AddRange(new string[] { "Core", "RakNet" });
+		PublicDependencyModuleNames.AddRange(new string[] { "Core", "RakNet" });
 
-        PublicIncludePaths.Add(Path.GetFullPath(Path.Combine(ModuleDirectory, "../../../../PhysX-3.4/PhysX_3.4/Samples/Replicas/Include")));
-    }
+		PublicIncludePaths.Add(Path.GetFullPath(Path.Combine(ModuleDirectory, "../../../../PhysX-3.4/PhysX_3.4/Samples/Replicas/Include")));
+	}
 }

--- a/Plugins/Replicas/Source/Replicas/Source
+++ b/Plugins/Replicas/Source/Replicas/Source
@@ -1,1 +1,0 @@
-D:/Git/OrionVisualiser/PhysX-3.4/PhysX_3.4/Samples/Replicas/Source

--- a/RN4UE4.uproject
+++ b/RN4UE4.uproject
@@ -1,26 +1,26 @@
 {
-  "FileVersion": 3,
-  "EngineAssociation": "4.19",
-  "Category": "",
-  "Description": "",
-  "Modules": [
-    {
-      "Name": "RN4UE4",
-      "Type": "Runtime",
-      "LoadingPhase": "Default",
-      "AdditionalDependencies": [
-        "Engine"
-      ]
-    }
-  ],
-  "Plugins": [
-    {
-      "Name": "RakNet",
-      "Enabled": true
-    },
-    {
-      "Name": "Replicas",
-      "Enabled": true
-    }
-  ]
+	"FileVersion": 3,
+	"EngineAssociation": "4.19",
+	"Category": "",
+	"Description": "",
+	"Modules": [
+		{
+			"Name": "RN4UE4",
+			"Type": "Runtime",
+			"LoadingPhase": "Default",
+			"AdditionalDependencies": [
+				"Engine"
+			]
+		}
+	],
+	"Plugins": [
+		{
+			"Name": "RakNet",
+			"Enabled": true
+		},
+		{
+			"Name": "Replicas",
+			"Enabled": true
+		}
+	]
 }

--- a/RN4UE4.uproject
+++ b/RN4UE4.uproject
@@ -1,26 +1,32 @@
 {
-	"FileVersion": 3,
-	"EngineAssociation": "4.19",
-	"Category": "",
-	"Description": "",
-	"Modules": [
-		{
-			"Name": "RN4UE4",
-			"Type": "Runtime",
-			"LoadingPhase": "Default",
-			"AdditionalDependencies": [
-				"Engine"
-			]
-		}
-	],
-	"Plugins": [
-		{
-			"Name": "RakNet",
-			"Enabled": true
-		},
-		{
-			"Name": "Replicas",
-			"Enabled": true
-		}
-	]
+  "FileVersion": 3,
+  "EngineAssociation": "4.19",
+  "Category": "",
+  "Description": "",
+  "Modules": [
+    {
+      "Name": "RN4UE4",
+      "Type": "Runtime",
+      "LoadingPhase": "Default",
+      "AdditionalDependencies": [
+        "Engine"
+      ]
+    }
+  ],
+  "Plugins": [
+    {
+      "Name": "RakNet",
+      "Enabled": true
+    },
+    {
+      "Name": "Replicas",
+      "Enabled": true
+    }
+  ],
+  "PreBuildSteps": {
+    "Win64": [
+      "xcopy $(ProjectDir)\\PhysX-3.4\\PhysX_3.4\\Samples\\Replicas\\Source $(ProjectDir)\\Plugins\\Replicas\\Source\\Replicas\\Source /e /i /y",
+      "xcopy $(ProjectDir)\\PhysX-3.4\\PhysX_3.4\\Samples\\Replicas\\Include $(ProjectDir)\\Plugins\\Replicas\\Source\\Replicas\\Public /e /i /y"
+    ]
+  }
 }

--- a/RN4UE4.uproject
+++ b/RN4UE4.uproject
@@ -22,11 +22,5 @@
       "Name": "Replicas",
       "Enabled": true
     }
-  ],
-  "PreBuildSteps": {
-    "Win64": [
-      "xcopy $(ProjectDir)\\PhysX-3.4\\PhysX_3.4\\Samples\\Replicas\\Source $(ProjectDir)\\Plugins\\Replicas\\Source\\Replicas\\Source /e /i /y",
-      "xcopy $(ProjectDir)\\PhysX-3.4\\PhysX_3.4\\Samples\\Replicas\\Include $(ProjectDir)\\Plugins\\Replicas\\Source\\Replicas\\Public /e /i /y"
-    ]
-  }
+  ]
 }

--- a/Source/RN4UE4/RN4UE4.Build.cs
+++ b/Source/RN4UE4/RN4UE4.Build.cs
@@ -4,11 +4,11 @@ using UnrealBuildTool;
 
 public class RN4UE4 : ModuleRules
 {
-    public RN4UE4(ReadOnlyTargetRules Target) : base (Target)
-    {
-        PublicDependencyModuleNames.AddRange(new string[] { "Core", "CoreUObject", "Engine", "InputCore", "RakNet", "Replicas", "PhysX", "APEX" });
+	public RN4UE4(ReadOnlyTargetRules Target) : base(Target)
+	{
+		PublicDependencyModuleNames.AddRange(new string[] { "Core", "CoreUObject", "Engine", "InputCore", "RakNet", "Replicas", "PhysX", "APEX" });
 
-        MinFilesUsingPrecompiledHeaderOverride = 1;
-        bFasterWithoutUnity = false;
-    }
+		MinFilesUsingPrecompiledHeaderOverride = 1;
+		bFasterWithoutUnity = false;
+	}
 }

--- a/Source/RN4UE4/RN4UE4.Build.cs
+++ b/Source/RN4UE4/RN4UE4.Build.cs
@@ -8,34 +8,7 @@ public class RN4UE4 : ModuleRules
     {
         PublicDependencyModuleNames.AddRange(new string[] { "Core", "CoreUObject", "Engine", "InputCore", "RakNet", "Replicas", "PhysX", "APEX" });
 
-        PrivateDependencyModuleNames.AddRange(new string[] { "RakNet", });
-
-		PublicIncludePaths.AddRange(new string[] { "RakNet/Public", });
-
-		PrivateIncludePaths.AddRange(new string[] { "RakNet/Private", });
-
-		PrivateIncludePathModuleNames.AddRange(new string[] { "RakNet", });
-
-
-        PrivateDependencyModuleNames.AddRange(new string[] { "Replicas", });
-
-        PublicIncludePaths.AddRange(new string[] { "Replicas/Public" });
-        PublicIncludePaths.AddRange(new string[] { "Replicas/Include" });
-
-        PrivateIncludePaths.AddRange(new string[] { "Replicas/Private" });
-		PrivateIncludePaths.AddRange(new string[] { "Replicas/Source" });
-
-        PrivateIncludePathModuleNames.AddRange(new string[] { "Replicas", });
-
-        // Uncomment if you are using Slate UI
-        // PrivateDependencyModuleNames.AddRange(new string[] { "Slate", "SlateCore" });
-
-        // Uncomment if you are using online features
-        // PrivateDependencyModuleNames.Add("OnlineSubsystem");
-
-        // To include OnlineSubsystemSteam, add it to the plugins section in your uproject file with the Enabled attribute set to true
-
         MinFilesUsingPrecompiledHeaderOverride = 1;
-		bFasterWithoutUnity = false;
-	}
+        bFasterWithoutUnity = false;
+    }
 }

--- a/Source/RN4UE4/RakNetRP.cpp
+++ b/Source/RN4UE4/RakNetRP.cpp
@@ -4,7 +4,7 @@
 #include "RakNetRP.h"
 #include <functional>
 #include <string>
-#include "Include/ReplicaBase.h"
+#include "ReplicaBase.h"
 
 using namespace std::placeholders;
 

--- a/Source/RN4UE4/Replica.h
+++ b/Source/RN4UE4/Replica.h
@@ -15,7 +15,7 @@
 #include "Rand.h"
 
 #include "GameFramework/Actor.h"
-#include "Include/ReplicaRigidDynamic.h"
+#include "ReplicaRigidDynamic.h"
 #include "Replica.generated.h"
 
 

--- a/Source/RN4UE4/ReplicaRigidDynamicClient.h
+++ b/Source/RN4UE4/ReplicaRigidDynamicClient.h
@@ -4,7 +4,7 @@
 
 #include "CoreMinimal.h"
 #include "Components/ActorComponent.h"
-#include "Include/ReplicaRigidDynamic.h"
+#include "ReplicaRigidDynamic.h"
 #include "RakNetRP.h"
 #include "ReplicaRigidDynamicClient.generated.h"
 


### PR DESCRIPTION
Work around the out-of-tree plugin sources problem by adding a pre-build step which simply copies the sources into place before every build.

By using the `Public` folder for includes that other modules need access to, we can dramatically simplify the `Build.cs` files and use the module dependency mechanism to automatically forward them to dependant modules instead of adding include paths to them.

There's a commit that bumps the submodule so that the changes in https://github.com/Alexthegr92/PhysX-3.4/pull/18 are there, as the include paths are fixed here.

Finally, the SSH URL was used for the submodule instead of HTTP to avoid username/password entry in Git.