### PR TITLE
Fix build failure from clean repo

### DIFF
--- a/Plugins/RakNet/Source/RakNet/Private/RakNetPrivatePCH.h
+++ b/Plugins/RakNet/Source/RakNet/Private/RakNetPrivatePCH.h
@@ -1,7 +1,7 @@
 // Copyright 1998-2016 Epic Games, Inc. All Rights Reserved.
 
+#include "Engine.h"
 #include "RakNet.h"
-//#include "Engine.h"
 
 // You should place include statements to your module's private header files here.  You only need to
 // add includes for headers that are used in most of your module's source files though.

--- a/Plugins/RakNet/Source/RakNet/RakNet.Build.cs
+++ b/Plugins/RakNet/Source/RakNet/RakNet.Build.cs
@@ -8,6 +8,12 @@ public class RakNet : ModuleRules
 	{
 		PCHUsage = ModuleRules.PCHUsageMode.UseExplicitOrSharedPCHs;
 		
+		PrivateDefinitions.AddRange(new string[]
+		{
+			"_CRT_SECURE_NO_WARNINGS",
+			"_WINSOCK_DEPRECATED_NO_WARNINGS",
+		});
+		
 		PublicIncludePaths.AddRange(
 			new string[] {
 				"RakNet/Public"

--- a/Plugins/RakNet/Source/RakNet/RakNet.Build.cs
+++ b/Plugins/RakNet/Source/RakNet/RakNet.Build.cs
@@ -37,7 +37,7 @@ public class RakNet : ModuleRules
 		PrivateDependencyModuleNames.AddRange(
 			new string[]
 			{
-				// ... add private dependencies that you statically link with here ...	
+				"Engine"
 			}
 			);
 		

--- a/Plugins/Replicas/Replicas.uplugin
+++ b/Plugins/Replicas/Replicas.uplugin
@@ -28,7 +28,7 @@
 	],
 	"PreBuildSteps": {
 		"Win64": [
-			"xcopy $(ProjectDir)\\PhysX-3.4\\PhysX_3.4\\Samples\\Replicas\\Source $(ProjectDir)\\Plugins\\Replicas\\Source\\Replicas\\Source /e /i /y"
+			"if not exist $(ProjectDir)/Plugins/Replicas/Source/Replicas/Source/*.cpp echo Can't find Replica sources - did you run generate_symlinks.bat? && exit /b 1"
 		]
 	}
 }

--- a/generate_symlinks.bat
+++ b/generate_symlinks.bat
@@ -1,0 +1,31 @@
+@echo off
+
+set REPLICA_SOURCE=PhysX-3.4\PhysX_3.4\Samples\Replicas\Source
+set JUNCTION_DESTINATION=Plugins\Replicas\Source\Replicas\Source
+
+set arg0=%0
+
+:: Does the submodule exist?
+if not exist %REPLICA_SOURCE%/*.cpp goto no_submodule
+
+:: Create a junction to the Replica sources folder
+if exist %JUNCTION_DESTINATION% goto junction_already_exists
+mklink /j %JUNCTION_DESTINATION% %REPLICA_SOURCE%
+goto ok_exit
+
+:no_submodule
+echo Couldn't find sources in %REPLICA_SOURCE% - did you checkout the submodule with 'git submodule update --init?'
+goto error_exit
+
+:junction_already_exists
+echo %JUNCTION_DESTINATION% already exists, or this script has been run already.
+goto error_exit
+
+:error_exit
+:: Pause only if we were launched with a double click
+if [%arg0:~2,1%]==[:] pause
+exit /b 1
+
+:ok_exit
+if [%arg0:~2,1%]==[:] pause
+exit /b 0


### PR DESCRIPTION
With a completely clean source tree (achieved with `git clean -xfd` to remove all files not tracked by git) the project fails to build for two reasons:

1. RakNet is missing an include.
2. The file copy from submodule Replica sources to Plugin Replica sources happens too late because PreBuildSteps seem to happen after the directories have been scanned.

1 is fixed by re-adding the missing include to the precompiled header (for some reason it was commented out),
2 is fixed by checking the sources exist - if not, an error is thrown prompting the developer to run the included batch file `generate_symlinks.bat`. This checks for presence of the submodule Replica source folder and tries to link it to the Plugin Replica source folder using a directory junction (a type of symlink on Windows that doesn't need Admin rights or other weird stuff).

Bonus: disable some warnings thrown during RakNet build process.
